### PR TITLE
CommandRouteBuilder implements IRouteBuilder

### DIFF
--- a/src/Sample/Startup.cs
+++ b/src/Sample/Startup.cs
@@ -3,7 +3,6 @@ using CommandRouting.Configure;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Hosting;
 using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Sample.Commands.SayHello;
 
@@ -22,9 +21,7 @@ namespace Sample
         {
             app.UseIISPlatformHandler();
 
-            RouteBuilder routeBuilder = new RouteBuilder {ServiceProvider = app.ApplicationServices};
-
-            CommandRouteBuilder commandRoutes = new CommandRouteBuilder(routeBuilder);
+            var commandRoutes = new CommandRouteBuilder(app.ApplicationServices);
 
             commandRoutes
                 .Get("hello/{name:alpha}")
@@ -36,7 +33,7 @@ namespace Sample
                 .As<SayHelloRequest>()
                 .RoutesTo<PostHello>();
 
-            app.UseRouter(routeBuilder.Build());
+            app.UseRouter(commandRoutes.Build());
 
             app.Run(HelloWorld);
         }


### PR DESCRIPTION
CommandRouteBuilder required an implementation of IRouteBuilder as a dependency.
It looked to be like, as its name says, that's the builder itself.
Having CommandRouteBuilder implement IRouteBuilder simplifies both the consumer code (refer to Startup.cs) and the builder code itself (no longer requires IRouteBuilder which could or could not have a IServiceProvider available)